### PR TITLE
[Refact] Extrair Método

### DIFF
--- a/src/main/java/TPPE_TDD/Main.java
+++ b/src/main/java/TPPE_TDD/Main.java
@@ -48,7 +48,7 @@ public class Main {
         
         String result_directory = JOptionPane.showInputDialog("Em que diretorio deseja salvar os resultados (digite sem a / no final)?");
         try {
-            parser.writeResults(selected_format, result_directory);
+            parser.selectFormatAndPersist(selected_format, result_directory);
         } catch (ArquivoNaoEncontradoException | EscritaNaoPermitidaException ex) {
             Logger.getLogger(Main.class.getName()).log(Level.SEVERE, null, ex);
             JOptionPane.showMessageDialog(null, ex.getMessage(),"Erro" ,JOptionPane.ERROR_MESSAGE);

--- a/src/main/java/TPPE_TDD/Parser.java
+++ b/src/main/java/TPPE_TDD/Parser.java
@@ -126,21 +126,24 @@ public class Parser {
         return result;
     
     }
-
-    public void writeResults(int mode, String caminhoSaida) throws ArquivoNaoEncontradoException, EscritaNaoPermitidaException{
-        
-        String result = 1==mode?getParsedResultLines():getParsedResultColumns();
-        String arquivoSaida = caminhoSaida+"/";
-        arquivoSaida += "analysisTime.out".equals(this.arquivoEntrada) ? "analysisTimeTab.out" : "analysisMemoryTab.out";
-
-        
+    
+    
+    private void writeResultsToFile(String content, String arquivoSaida) throws ArquivoNaoEncontradoException, EscritaNaoPermitidaException{
+                
         try (PrintWriter out = new PrintWriter(arquivoSaida)) {
-            out.println(result);
+            out.println(content);
         } catch (Exception ex) {
            throw new EscritaNaoPermitidaException();
         }
     
     }
     
+    public void selectFormatAndPersist(int mode, String caminhoSaida)throws ArquivoNaoEncontradoException, EscritaNaoPermitidaException{
+        String result = 1==mode?getParsedResultLines():getParsedResultColumns();
+        String arquivoSaida = caminhoSaida+"/";
+        arquivoSaida += "analysisTime.out".equals(this.arquivoEntrada) ? "analysisTimeTab.out" : "analysisMemoryTab.out";        
+        writeResultsToFile(result,arquivoSaida);
+        
+    }
 
 }

--- a/src/test/java/TPPE_TDD/FileWriting.java
+++ b/src/test/java/TPPE_TDD/FileWriting.java
@@ -19,7 +19,7 @@ public class FileWriting {
     public void testWriteResults() throws ArquivoNaoEncontradoException, DelimitadorInvalidoException, EscritaNaoPermitidaException {
         Parser parser = new Parser("analysisMemory.out");
         parser.setDelimitador(";");
-        parser.writeResults(1,"results");
+        parser.selectFormatAndPersist(1,"results");
         File file = new File("results/analysisMemoryTab.out");
         assertTrue(file.exists());
     }
@@ -28,7 +28,7 @@ public class FileWriting {
     public void testWriteResultsDOis() throws ArquivoNaoEncontradoException, DelimitadorInvalidoException, EscritaNaoPermitidaException {
         Parser parser = new Parser("analysisTime.out");
         parser.setDelimitador(";");
-        parser.writeResults(1,"results");
+        parser.selectFormatAndPersist(1,"results");
         File file = new File("results/analysisTimeTab.out");
         assertTrue(file.exists());
     }
@@ -37,7 +37,7 @@ public class FileWriting {
     public void testWriteResultsThree() throws ArquivoNaoEncontradoException, DelimitadorInvalidoException, EscritaNaoPermitidaException {
         Parser parser = new Parser("analysisMemory.out");
         parser.setDelimitador(",");
-        parser.writeResults(0,"results");
+        parser.selectFormatAndPersist(0,"results");
         File file = new File("results/analysisMemoryTab.out");
         assertTrue(file.exists());
     }


### PR DESCRIPTION
Origem: Parser.java
Impactos: métodos writeResults, writeResultsToFile, selectFormatAndPersist e readInput. Todos em Parser.java

Explicação: Agora existe um método writeResultsToFile que tem a responsabilidade única de
gravar um conteúdo no arquivo de saída. Similarmente, há um método readInput com a responsabilidade
única de ler o conteúdo do arquivo de entrada.
Foi criado também um novo método chamado selectFormatAndPersist, que chama o writeResultsToFile para
persistir os resultados de acordo com a opção do usuário, linhas ou colunas.