### PR TITLE
[Refact] Substituir método por objeto-método

### DIFF
--- a/src/main/java/TPPE_TDD/ContentParser.java
+++ b/src/main/java/TPPE_TDD/ContentParser.java
@@ -1,0 +1,97 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package TPPE_TDD;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ *
+ * @author marcos
+ */
+public class ContentParser {
+    
+    
+    private Integer maxLines;
+    private String delimitador;
+
+    public ContentParser(String delimitador){
+        this.delimitador = delimitador;
+    }
+    
+    private ArrayList<ArrayList<Double>> matrizDeValores(List<String> content) throws ArquivoNaoEncontradoException{
+        ArrayList<ArrayList<Double>> matriz = new ArrayList<>();
+        ArrayList<Double> temp= new ArrayList<>();
+        Integer current = 0;
+        this.maxLines=0;
+
+        for(String line : content){
+
+            if(line.startsWith("-")){
+                if(current>0){
+                    if(current>this.maxLines)this.maxLines=current;
+                    current=0;
+                    matriz.add(temp);
+                    temp = new ArrayList<>();              
+                }
+                continue;
+            }
+            temp.add(Double.parseDouble(line));
+            current++;
+        }
+
+
+        if(current>this.maxLines)this.maxLines=current;
+        matriz.add(temp);
+
+        return matriz;
+    }   
+        
+    public String getParsedResultLines(List<String> content) throws ArquivoNaoEncontradoException{
+    
+        String result = "";
+        
+        int evolution = 1 ;
+        for(ArrayList<Double> item: matrizDeValores(content)){
+            result+= evolution+ this.delimitador;
+            for(Double number: item){
+               result+= number+ this.delimitador;
+            }
+            result+= "\n";
+            evolution++;
+        }
+      
+        return result;
+    
+    }
+    
+    public String getParsedResultColumns(List<String> content) throws ArquivoNaoEncontradoException{
+    
+        String result = "";
+        ArrayList<ArrayList<Double>> matriz = matrizDeValores(content);
+        
+        for(int i =1;i<=matriz.size();i++){
+           result+= i+this.delimitador;
+        }
+        
+        result+="\n";
+        
+        for(int j=0; j<maxLines;j++){
+          for(int i =0;i<matriz.size();i++){
+             if(matriz.get(i).size()>j)
+                result+= matriz.get(i).get(j)+this.delimitador;
+             else
+                 result+="\t";
+          }  
+          result+="\n";
+        }
+        
+        return result;
+    
+    }
+    
+    
+}

--- a/src/main/java/TPPE_TDD/Main.java
+++ b/src/main/java/TPPE_TDD/Main.java
@@ -26,8 +26,8 @@ public class Main {
                             "Selecao de entrada",
                             JOptionPane.DEFAULT_OPTION, JOptionPane.INFORMATION_MESSAGE, null, options_input, options_input[0]);
        
-       Parser parser;
-       parser = new Parser(options_input[selected_input]);
+       UseParser parser;
+       parser = new UseParser(options_input[selected_input]);
        
        String delimitador = JOptionPane.showInputDialog("Qual delimitador voce gostaria de usar?");
         try {

--- a/src/main/java/TPPE_TDD/UseParser.java
+++ b/src/main/java/TPPE_TDD/UseParser.java
@@ -21,13 +21,13 @@ import java.util.logging.Logger;
  *
  * @author marcos
  */
-public class Parser {
+public class UseParser {
 
    private String arquivoEntrada;
    private String delimitador;
    private Integer max;
 
-    public Parser(String arquivoEntrada) {
+    public UseParser(String arquivoEntrada) {
         this.arquivoEntrada = arquivoEntrada;
     }
 
@@ -56,73 +56,16 @@ public class Parser {
         return this.delimitador;
     } 
 
-    private ArrayList<ArrayList<Double>> matrizDeValores() throws ArquivoNaoEncontradoException{
-        ArrayList<ArrayList<Double>> matriz = new ArrayList<>();
-        ArrayList<Double> temp= new ArrayList<>();
-        Integer current = 0;
-        this.max=0;
-    
-        for(String line : readInput()){
-                            
-            if(line.startsWith("-")){
-                if(current>0){
-                    if(current>this.max)this.max=current;
-                    current=0;
-                    matriz.add(temp);
-                    temp = new ArrayList<>();              
-                }
-                continue;
-            }
-            temp.add(Double.parseDouble(line));
-            current++;
-        }
-            
-            
-        if(current>this.max)this.max=current;
-        matriz.add(temp);
-        
-        return matriz;
-    }
     
     public String getParsedResultLines() throws ArquivoNaoEncontradoException{
-    
-        String result = "";
-        
-        int evolution = 1 ;
-        for(ArrayList<Double> item: matrizDeValores()){
-            result+= evolution+ this.delimitador;
-            for(Double number: item){
-               result+= number+ this.delimitador;
-            }
-            result+= "\n";
-            evolution++;
-        }
-      
+        ContentParser parser = new ContentParser(this.delimitador);
+        String result = parser.getParsedResultLines(readInput());
         return result;
-    
     }
     
     public String getParsedResultColumns() throws ArquivoNaoEncontradoException{
-    
-        String result = "";
-        ArrayList<ArrayList<Double>> matriz = matrizDeValores();
-        
-        for(int i =1;i<=matriz.size();i++){
-           result+= i+this.delimitador;
-        }
-        
-        result+="\n";
-        
-        for(int j=0; j<max;j++){
-          for(int i =0;i<matriz.size();i++){
-             if(matriz.get(i).size()>j)
-                result+= matriz.get(i).get(j)+this.delimitador;
-             else
-                 result+="\t";
-          }  
-          result+="\n";
-        }
-        
+        ContentParser parser = new ContentParser(this.delimitador);
+        String result = parser.getParsedResultColumns(readInput());
         return result;
     
     }

--- a/src/test/java/TPPE_TDD/DelimitadorTest.java
+++ b/src/test/java/TPPE_TDD/DelimitadorTest.java
@@ -17,28 +17,28 @@ public class DelimitadorTest {
     
     @Test
     public void testDelimitador() throws DelimitadorInvalidoException {
-        Parser parser = new Parser("src/test/fixtures/testFixture.txt");
+        UseParser parser = new UseParser("src/test/fixtures/testFixture.txt");
         parser.setDelimitador(";");
         assertEquals(parser.getDelimitador(), ";");
     }
     
     @Test
     public void testDelimitadorDois() throws DelimitadorInvalidoException {
-        Parser parser = new Parser("src/test/fixtures/testFixture.txt");
+        UseParser parser = new UseParser("src/test/fixtures/testFixture.txt");
         parser.setDelimitador("\t");
         assertEquals(parser.getDelimitador(), "\t");
     }    
     
     @Test
     public void testDelimitadorTres() throws DelimitadorInvalidoException {
-        Parser parser = new Parser("src/test/fixtures/testFixture.txt");
+        UseParser parser = new UseParser("src/test/fixtures/testFixture.txt");
         parser.setDelimitador("-");
         assertEquals(parser.getDelimitador(), "-");
     }    
     
     @Test(expected = DelimitadorInvalidoException.class)
     public void testDelimitadorException() throws DelimitadorInvalidoException {
-        Parser parser = new Parser("src/test/fixtures/testFixture.txt");
+        UseParser parser = new UseParser("src/test/fixtures/testFixture.txt");
         parser.setDelimitador("delimitador-invalido");
         assertEquals(parser.getDelimitador(), ";");
     }

--- a/src/test/java/TPPE_TDD/FileReadingTest.java
+++ b/src/test/java/TPPE_TDD/FileReadingTest.java
@@ -22,28 +22,28 @@ public class FileReadingTest {
 
     @Test
     public void testLeArquivo() throws ArquivoNaoEncontradoException {
-        Parser parser = new Parser("src/test/fixtures/testFixture.txt");
+        UseParser parser = new UseParser("src/test/fixtures/testFixture.txt");
         List<String> fileContents = parser.readInput();
         assertEquals(fileContents.get(0), "test file contents");
     }
     
     @Test
     public void testLeArquivoDois() throws ArquivoNaoEncontradoException {
-        Parser parser = new Parser("src/test/fixtures/testFixtureDois.txt");
+        UseParser parser = new UseParser("src/test/fixtures/testFixtureDois.txt");
         List<String> fileContents = parser.readInput();
         assertEquals(fileContents.get(0), "second test file contents");
     }
     
     @Test
     public void testLeArquivoTres() throws ArquivoNaoEncontradoException {
-        Parser parser = new Parser("src/test/fixtures/testFixtureTres.txt");
+        UseParser parser = new UseParser("src/test/fixtures/testFixtureTres.txt");
         List<String> fileContents = parser.readInput();
         assertEquals(fileContents.get(0), "third test file contents");
     }
  
     @Test(expected = ArquivoNaoEncontradoException.class)
     public void testLeArquivoException() throws ArquivoNaoEncontradoException {
-        Parser parser = new Parser("src/test/fixtures/unexistent.txt");
+        UseParser parser = new UseParser("src/test/fixtures/unexistent.txt");
         List<String> fileContents = parser.readInput();
         assertEquals(fileContents.get(0), "");
     }

--- a/src/test/java/TPPE_TDD/FileWriting.java
+++ b/src/test/java/TPPE_TDD/FileWriting.java
@@ -17,7 +17,7 @@ import org.junit.Test;
 public class FileWriting {
     @Test
     public void testWriteResults() throws ArquivoNaoEncontradoException, DelimitadorInvalidoException, EscritaNaoPermitidaException {
-        Parser parser = new Parser("analysisMemory.out");
+        UseParser parser = new UseParser("analysisMemory.out");
         parser.setDelimitador(";");
         parser.selectFormatAndPersist(1,"results");
         File file = new File("results/analysisMemoryTab.out");
@@ -26,7 +26,7 @@ public class FileWriting {
 
     @Test
     public void testWriteResultsDOis() throws ArquivoNaoEncontradoException, DelimitadorInvalidoException, EscritaNaoPermitidaException {
-        Parser parser = new Parser("analysisTime.out");
+        UseParser parser = new UseParser("analysisTime.out");
         parser.setDelimitador(";");
         parser.selectFormatAndPersist(1,"results");
         File file = new File("results/analysisTimeTab.out");
@@ -35,7 +35,7 @@ public class FileWriting {
     
     @Test
     public void testWriteResultsThree() throws ArquivoNaoEncontradoException, DelimitadorInvalidoException, EscritaNaoPermitidaException {
-        Parser parser = new Parser("analysisMemory.out");
+        UseParser parser = new UseParser("analysisMemory.out");
         parser.setDelimitador(",");
         parser.selectFormatAndPersist(0,"results");
         File file = new File("results/analysisMemoryTab.out");

--- a/src/test/java/TPPE_TDD/ParsingTest.java
+++ b/src/test/java/TPPE_TDD/ParsingTest.java
@@ -16,39 +16,39 @@ import org.junit.Test;
 public class ParsingTest {
     @Test
     public void testParseLinhas() throws ArquivoNaoEncontradoException, DelimitadorInvalidoException {
-        Parser parser = new Parser("src/test/fixtures/testFixtureParsing.txt");
+        UseParser parser = new UseParser("src/test/fixtures/testFixtureParsing.txt");
         parser.setDelimitador(";");
         assertEquals(parser.getParsedResultLines(), "1;456.0;782.0;\n2;523.0;861.0;\n");
     }
     @Test
     public void testParseLinhasDois() throws ArquivoNaoEncontradoException, DelimitadorInvalidoException {
-        Parser parser = new Parser("src/test/fixtures/testFixtureParsing.txt");
+        UseParser parser = new UseParser("src/test/fixtures/testFixtureParsing.txt");
         parser.setDelimitador("-");
         assertEquals(parser.getParsedResultLines(), "1-456.0-782.0-\n2-523.0-861.0-\n");
     }
     @Test
     public void testParseLinhasTres() throws ArquivoNaoEncontradoException, DelimitadorInvalidoException {
-        Parser parser = new Parser("src/test/fixtures/testFixtureParsingDois.txt");
+        UseParser parser = new UseParser("src/test/fixtures/testFixtureParsingDois.txt");
         parser.setDelimitador(";");
         assertEquals(parser.getParsedResultLines(), "1;1000.0;782.0;\n2;523.0;861.0;\n");
     }
     
     @Test
     public void testParseColunas() throws ArquivoNaoEncontradoException, DelimitadorInvalidoException {
-        Parser parser = new Parser("src/test/fixtures/testFixtureParsing.txt");
+        UseParser parser = new UseParser("src/test/fixtures/testFixtureParsing.txt");
         parser.setDelimitador(";");
         assertEquals(parser.getParsedResultColumns(), "1;2;\n456.0;523.0;\n782.0;861.0;\n");
     }
     
     @Test
     public void testParseColunasDois() throws ArquivoNaoEncontradoException, DelimitadorInvalidoException {
-        Parser parser = new Parser("src/test/fixtures/testFixtureParsing.txt");
+        UseParser parser = new UseParser("src/test/fixtures/testFixtureParsing.txt");
         parser.setDelimitador("-");
         assertEquals(parser.getParsedResultColumns(), "1-2-\n456.0-523.0-\n782.0-861.0-\n");
     }
     @Test
     public void testParseColunasTres() throws ArquivoNaoEncontradoException, DelimitadorInvalidoException {
-        Parser parser = new Parser("src/test/fixtures/testFixtureParsingDois.txt");
+        UseParser parser = new UseParser("src/test/fixtures/testFixtureParsingDois.txt");
         parser.setDelimitador("-");
         assertEquals(parser.getParsedResultColumns(), "1-2-\n1000.0-523.0-\n782.0-861.0-\n");
     }


### PR DESCRIPTION
Origem: UseParser.java
Impactos: métodos getParsedResultLines, getParsedResultColumns e matrizDeValores em UseParser.java.
Classe ContentParser e seus métodos matrizDeValores, getParsedResultLines e getParsedResultColumns.

Explicação: com a operação de refatoração aplicada, agora os métodos que transformam os valores lidos
pros formatos de linhas ou colunas se tornaram apenas indireções que chamam os objetos-método que realmente
possuem essas responsabilidades. Para tal, a classe Parser também foi renomeada para UseParser, para que
a classe com os objetos método se chame ContentParser. Com isso a classe UseParser ficou mais limpa, e
as responsabilidades de transfor o conteúdo em linhas ou colunas pôde ser isolada.